### PR TITLE
fix build on macos and debian

### DIFF
--- a/keystone-sys/build.rs
+++ b/keystone-sys/build.rs
@@ -25,7 +25,10 @@ fn build_keystone() {
     );
     println!("cargo:rustc-link-lib={}={}", "static", KEYSTONE_LIB);
 
-    #[cfg(target_family = "unix")]
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-lib=dylib=c++");
+
+    #[cfg(all(unix, not(target_os = "macos")))]
     println!("cargo:rustc-link-lib=dylib=stdc++");
 }
 

--- a/keystone-sys/build.rs
+++ b/keystone-sys/build.rs
@@ -7,6 +7,7 @@ fn build_keystone() {
     let mut cmake_config = cmake::Config::new(KEYSTONE_C);
     cmake_config
         .define("BUILD_SHARED_LIBS", "OFF")
+        .define("CMAKE_INSTALL_LIBDIR", "lib64")
         .define("CMAKE_BUILD_TYPE", "Release");
 
     #[cfg(target_family = "windows")]


### PR DESCRIPTION
Ref #2
On some system (like debian) the keystone library is built under `lib/` by default instead of `lib64/`.
Since the `rustc-link-search` is set to search in a `lib64/` directory, add a cmake config to always build keystone to a `lib64/` directory.